### PR TITLE
feat: Redirect authenticated users to business generator page

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,9 @@
       "Bash(npm cache clean:*)",
       "Bash(sudo rm:*)",
       "Bash(OPENAI_API_KEY=dummy_key npx playwright test tests/enhanced-vs-basic-analysis.test.ts --reporter=line)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,10 @@
       "Bash(OPENAI_API_KEY=dummy_key npx playwright test tests/enhanced-vs-basic-analysis.test.ts --reporter=line)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)"
     ],
     "deny": []
   }

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -38,8 +38,8 @@ export function LoginForm({
         password,
       });
       if (error) throw error;
-      // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push("/protected");
+      // Redirect to business generator page after successful login.
+      router.push("/business-generator");
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : "An error occurred");
     } finally {

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -44,7 +44,7 @@ export function SignUpForm({
         email,
         password,
         options: {
-          emailRedirectTo: `${window.location.origin}/protected`,
+          emailRedirectTo: `${window.location.origin}/business-generator`,
         },
       });
       if (error) throw error;

--- a/components/update-password-form.tsx
+++ b/components/update-password-form.tsx
@@ -33,8 +33,8 @@ export function UpdatePasswordForm({
     try {
       const { error } = await supabase.auth.updateUser({ password });
       if (error) throw error;
-      // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push("/protected");
+      // Redirect to business generator page after successful password update.
+      router.push("/business-generator");
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : "An error occurred");
     } finally {


### PR DESCRIPTION
## Summary
• ログイン後のリダイレクト先を/protectedから/business-generatorに変更
• ユーザー体験の向上：認証後に直接メイン機能にアクセス

## 変更内容
- ログイン成功時のリダイレクト先変更
- パスワード更新後のリダイレクト先変更  
- メール認証後のリダイレクト先変更
- 新規登録メール確認後のリダイレクト先変更

## 影響するファイル
- `components/login-form.tsx`
- `components/update-password-form.tsx`
- `components/sign-up-form.tsx`

## Test plan
- [x] ログイン → /business-generatorリダイレクト確認
- [x] パスワード更新 → /business-generatorリダイレクト確認
- [x] メール認証 → /business-generatorリダイレクト確認

🤖 Generated with [Claude Code](https://claude.ai/code)